### PR TITLE
nginx.config code uodate 2

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -14,7 +14,7 @@ server {
 
   # SPA fallback: all other routes go to index.html
   location / {
-    try_files $uri /index.html;
+    try_files $uri $uri/ /index.html;
     index index.html;
   }
 


### PR DESCRIPTION
Fix: Use relative base path and correct output directory for Vite + Nginx SPA deployment